### PR TITLE
Add linear combination to the vector API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ PMT_SOURCES := \
 	pmt_vec_add_to.c \
 	pmt_vec_copy.c \
 	pmt_vec_fill.c \
+	pmt_vec_fma.c \
+	pmt_vec_fma_to.c \
 	pmt_vec_scale.c \
 	pmt_vec_scale_to.c \
 	pmt_vec_sub.c \
@@ -24,6 +26,7 @@ VEC_SOURCES := \
 	vector_init_zero.c \
 	vector_init_from_value.c \
 	vector_init_from_array.c \
+	vector_linear_combine.c \
 	vector_fill.c \
 	vector_scale.c \
 	vector_scale_to.c \

--- a/include/libmatrix_version.h
+++ b/include/libmatrix_version.h
@@ -6,7 +6,7 @@
 #define __LIBMX_STR2(x) #x
 
 #define LIBMATRIX_MAJOR 0
-#define LIBMATRIX_MINOR 3
+#define LIBMATRIX_MINOR 4
 #define LIBMATRIX_PATCH 0
 
 // Conditionally define the pre-release macro, so that people can test for its

--- a/include/primitives.h
+++ b/include/primitives.h
@@ -41,4 +41,12 @@ double *pmt_vec_scale(double *restrict dst, const double *restrict src,
 /// \brief Compute `dst *= factor`.
 double *pmt_vec_scale_to(double *dst, double factor, size_t size);
 
+/// \brief Compute `dst = lhs * factor + rhs`.
+double *pmt_vec_fma(double *restrict dst, const double *restrict lhs,
+    double factor, const double *restrict rhs, size_t size);
+
+/// \brief Compute `dst += src * factor`.
+double *pmt_vec_fma_to(double *restrict dst, const double *restrict src,
+    double factor, size_t size);
+
 #endif

--- a/include/vector.h
+++ b/include/vector.h
@@ -80,4 +80,11 @@ vector_t *vector_scale(
 /// \public \memberof vector_t
 vector_t *vector_scale_to(vector_t *dst, double factor);
 
+/// \brief Computes the linear combination of all the vectors in src using the
+/// given coefficients, storing the result in dst. This function assumes that
+/// src is an array of vectors.
+/// \public \memberof vector_t
+vector_t *vector_linear_combine(vector_t *restrict dst,
+    const vector_t *restrict src, const vector_t *restrict coeffs);
+
 #endif

--- a/sources/primitives/pmt_vec_add.c
+++ b/sources/primitives/pmt_vec_add.c
@@ -3,7 +3,7 @@
 double *pmt_vec_add(double *restrict dst, const double *restrict lhs,
     const double *restrict rhs, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] * rhs[i];
+    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] + rhs[i];
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_fma.c
+++ b/sources/primitives/pmt_vec_fma.c
@@ -1,0 +1,9 @@
+#include "primitives.h"
+
+double *pmt_vec_fma(double *restrict dst, const double *restrict lhs,
+    double factor, const double *restrict rhs, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] * factor + rhs[i];
+
+    return dst;
+}

--- a/sources/primitives/pmt_vec_fma_to.c
+++ b/sources/primitives/pmt_vec_fma_to.c
@@ -1,0 +1,9 @@
+#include "primitives.h"
+
+double *pmt_vec_fma_to(double *restrict dst, const double *restrict src,
+    double factor, size_t size)
+{
+    for (size_t i = 0; i < size; ++i) dst[i] += src[i] * factor;
+
+    return dst;
+}

--- a/sources/vector/vector_linear_combine.c
+++ b/sources/vector/vector_linear_combine.c
@@ -1,0 +1,19 @@
+#include "vector.h"
+
+vector_t *vector_linear_combine(vector_t *restrict dst,
+    const vector_t *restrict src, const vector_t *restrict coeffs)
+{
+    if (coeffs->count == 0) return dst;
+
+    assert(dst->count == src->count);
+    pmt_vec_scale(dst->values, src->values, coeffs->values[0], dst->count);
+
+    for (size_t i = 1; i < coeffs->count; ++i)
+    {
+        assert(dst->count == (src + i)->count);
+        pmt_vec_fma_to(
+            dst->values, (src + i)->values, coeffs->values[i], dst->count);
+    }
+
+    return dst;
+}


### PR DESCRIPTION
- Add a function for computing linear combinations to the vector API
- Add two functions for fused multiply-add operations to the primitive API
- Fix a bug in pmt_vec_add which was using the wrong operator for computations