### PR TITLE
Add vector linear interpolation functions

### DIFF
--- a/include/libmatrix_version.h
+++ b/include/libmatrix_version.h
@@ -6,7 +6,7 @@
 #define __LIBMX_STR2(x) #x
 
 #define LIBMATRIX_MAJOR 0
-#define LIBMATRIX_MINOR 4
+#define LIBMATRIX_MINOR 5
 #define LIBMATRIX_PATCH 0
 
 // Conditionally define the pre-release macro, so that people can test for its

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -77,32 +77,42 @@ void matrix_destroy(matrix_t *mat);
 /// \public \memberof matrix_t
 matrix_t *matrix_fill(matrix_t *mat, double value);
 
-/// \brief Compute the addition of lhs and rhs and store it in dst.
-/// \public \memberof matrix_t
-matrix_t *matrix_add(matrix_t *restrict dst, const matrix_t *restrict lhs,
-    const matrix_t *restrict rhs);
-
 /// \brief Add src to dst.
 /// \public \memberof matrix_t
-matrix_t *matrix_add_to(matrix_t *restrict dst, const matrix_t *restrict src);
+matrix_t *matrix_add(matrix_t *restrict dst, const matrix_t *restrict src);
 
-/// \brief Compute the subtraction of lhs and rhs and store it in dst.
+/// \brief Compute the addition of lhs and rhs and store it in dst.
 /// \public \memberof matrix_t
-matrix_t *matrix_sub(matrix_t *restrict dst, const matrix_t *restrict lhs,
+matrix_t *matrix_add_to(matrix_t *restrict dst, const matrix_t *restrict lhs,
     const matrix_t *restrict rhs);
 
 /// \brief Subtract src to dst.
 /// \public \memberof matrix_t
-matrix_t *matrix_sub_to(matrix_t *restrict dst, const matrix_t *restrict src);
+matrix_t *matrix_sub(matrix_t *restrict dst, const matrix_t *restrict src);
+
+/// \brief Compute the subtraction of lhs and rhs and store it in dst.
+/// \public \memberof matrix_t
+matrix_t *matrix_sub_to(matrix_t *restrict dst, const matrix_t *restrict lhs,
+    const matrix_t *restrict rhs);
+
+/// \brief Multiply each element in dst by factor.
+/// \public \memberof matrix_t
+matrix_t *matrix_scale(matrix_t *dst, double factor);
 
 /// \brief Compute the scalar multiplication of src by factor and store it in
 /// dst.
 /// \public \memberof matrix_t
-matrix_t *matrix_scale(
+matrix_t *matrix_scale_to(
     matrix_t *restrict dst, const matrix_t *restrict src, double factor);
 
-/// \brief Multiply each element in dst by factor.
+/// \brief Compute the linear interpolation of dst and src.
 /// \public \memberof matrix_t
-matrix_t *matrix_scale_to(matrix_t *dst, double factor);
+matrix_t *matrix_lerp(matrix_t *restrict dst,
+    const matrix_t *restrict src, double t);
+
+/// \brief Compute the linear interpolation of lhs and rhs and store it in dst.
+/// \public \memberof matrix_t
+matrix_t *matrix_lerp_to(matrix_t *restrict dst,
+    const matrix_t *restrict lhs, const matrix_t *restrict rhs, double t);
 
 #endif

--- a/include/primitives.h
+++ b/include/primitives.h
@@ -18,35 +18,35 @@ double *pmt_vec_copy(
 /// \brief Fill a buffer with a given value.
 double *pmt_vec_fill(double *dst, double value, size_t size);
 
-/// \brief Compute `dst = lhs + rhs`.
-double *pmt_vec_add(double *restrict dst, const double *restrict lhs,
-    const double *restrict rhs, size_t size);
-
 /// \brief Compute `dst += src`.
-double *pmt_vec_add_to(
+double *pmt_vec_add(
     double *restrict dst, const double *restrict src, size_t size);
 
-/// \brief Compute `dst = lhs - rhs`.
-double *pmt_vec_sub(double *restrict dst, const double *restrict lhs,
+/// \brief Compute `dst = lhs + rhs`.
+double *pmt_vec_add_to(double *restrict dst, const double *restrict lhs,
     const double *restrict rhs, size_t size);
 
 /// \brief Compute `dst -= src`.
-double *pmt_vec_sub_to(
+double *pmt_vec_sub(
     double *restrict dst, const double *restrict src, size_t size);
 
-/// \brief Compute `dst = src * factor`.
-double *pmt_vec_scale(double *restrict dst, const double *restrict src,
-    double factor, size_t size);
+/// \brief Compute `dst = lhs - rhs`.
+double *pmt_vec_sub_to(double *restrict dst, const double *restrict lhs,
+    const double *restrict rhs, size_t size);
 
 /// \brief Compute `dst *= factor`.
-double *pmt_vec_scale_to(double *dst, double factor, size_t size);
+double *pmt_vec_scale(double *dst, double factor, size_t size);
 
-/// \brief Compute `dst = lhs * factor + rhs`.
-double *pmt_vec_fma(double *restrict dst, const double *restrict lhs,
-    double factor, const double *restrict rhs, size_t size);
+/// \brief Compute `dst = src * factor`.
+double *pmt_vec_scale_to(double *restrict dst, const double *restrict src,
+    double factor, size_t size);
 
 /// \brief Compute `dst += src * factor`.
-double *pmt_vec_fma_to(double *restrict dst, const double *restrict src,
+double *pmt_vec_fma(double *restrict dst, const double *restrict src,
     double factor, size_t size);
+
+/// \brief Compute `dst = lhs * factor + rhs`.
+double *pmt_vec_fma_to(double *restrict dst, const double *restrict lhs,
+    double factor, const double *restrict rhs, size_t size);
 
 #endif

--- a/include/vector.h
+++ b/include/vector.h
@@ -52,39 +52,49 @@ void vector_destroy(vector_t *vec);
 /// \public \memberof vector_t
 vector_t *vector_fill(vector_t *vec, double value);
 
-/// \brief Compute the addition of lhs and rhs and store it in dst.
-/// \public \memberof vector_t
-vector_t *vector_add(vector_t *restrict dst, const vector_t *restrict lhs,
-    const vector_t *restrict rhs);
-
 /// \brief Add src to dst.
 /// \public \memberof vector_t
-vector_t *vector_add_to(vector_t *restrict dst, const vector_t *restrict src);
+vector_t *vector_add(vector_t *restrict dst, const vector_t *restrict src);
 
-/// \brief Compute the subtraction of lhs and rhs and store it in dst.
+/// \brief Compute the addition of lhs and rhs and store it in dst.
 /// \public \memberof vector_t
-vector_t *vector_sub(vector_t *restrict dst, const vector_t *restrict lhs,
+vector_t *vector_add_to(vector_t *restrict dst, const vector_t *restrict lhs,
     const vector_t *restrict rhs);
 
 /// \brief Subtract src to dst.
 /// \public \memberof vector_t
-vector_t *vector_sub_to(vector_t *restrict dst, const vector_t *restrict src);
+vector_t *vector_sub(vector_t *restrict dst, const vector_t *restrict src);
+
+/// \brief Compute the subtraction of lhs and rhs and store it in dst.
+/// \public \memberof vector_t
+vector_t *vector_sub_to(vector_t *restrict dst, const vector_t *restrict lhs,
+    const vector_t *restrict rhs);
+
+/// \brief Multiply each element in dst by factor.
+/// \public \memberof vector_t
+vector_t *vector_scale(vector_t *dst, double factor);
 
 /// \brief Compute the scalar multiplication of src by factor and store it in
 /// dst.
 /// \public \memberof vector_t
-vector_t *vector_scale(
+vector_t *vector_scale_to(
     vector_t *restrict dst, const vector_t *restrict src, double factor);
 
-/// \brief Multiply each element in dst by factor.
-/// \public \memberof vector_t
-vector_t *vector_scale_to(vector_t *dst, double factor);
-
-/// \brief Computes the linear combination of all the vectors in src using the
+/// \brief Compute the linear combination of all the vectors in src using the
 /// given coefficients, storing the result in dst. This function assumes that
 /// src is an array of vectors.
 /// \public \memberof vector_t
 vector_t *vector_linear_combine(vector_t *restrict dst,
     const vector_t *restrict src, const vector_t *restrict coeffs);
+
+/// \brief Compute the linear interpolation of dst and src.
+/// \public \memberof vector_t
+vector_t *vector_lerp(vector_t *restrict dst,
+    const vector_t *restrict src, double t);
+
+/// \brief Compute the linear interpolation of lhs and rhs and store it in dst.
+/// \public \memberof vector_t
+vector_t *vector_lerp_to(vector_t *restrict dst,
+    const vector_t *restrict lhs, const vector_t *restrict rhs, double t);
 
 #endif

--- a/sources/matrix/matrix_add.c
+++ b/sources/matrix/matrix_add.c
@@ -1,10 +1,8 @@
 #include "matrix.h"
 
-matrix_t *matrix_add(matrix_t *restrict dst, const matrix_t *restrict lhs,
-    const matrix_t *restrict rhs)
+matrix_t *matrix_add(matrix_t *restrict dst, const matrix_t *restrict src)
 {
-    assert(matrix_same_dimensions(dst, lhs));
-    assert(matrix_same_dimensions(dst, rhs));
-    pmt_vec_add(dst->values, lhs->values, rhs->values, matrix_size(dst));
+    assert(matrix_same_dimensions(dst, src));
+    pmt_vec_add(dst->values, src->values, matrix_size(dst));
     return dst;
 }

--- a/sources/matrix/matrix_add_to.c
+++ b/sources/matrix/matrix_add_to.c
@@ -1,8 +1,10 @@
 #include "matrix.h"
 
-matrix_t *matrix_add_to(matrix_t *restrict dst, const matrix_t *restrict src)
+matrix_t *matrix_add_to(matrix_t *restrict dst, const matrix_t *restrict lhs,
+    const matrix_t *restrict rhs)
 {
-    assert(matrix_same_dimensions(dst, src));
-    pmt_vec_add_to(dst->values, src->values, matrix_size(dst));
+    assert(matrix_same_dimensions(dst, lhs));
+    assert(matrix_same_dimensions(dst, rhs));
+    pmt_vec_add_to(dst->values, lhs->values, rhs->values, matrix_size(dst));
     return dst;
 }

--- a/sources/matrix/matrix_scale.c
+++ b/sources/matrix/matrix_scale.c
@@ -1,9 +1,7 @@
 #include "matrix.h"
 
-matrix_t *matrix_scale(
-    matrix_t *restrict dst, const matrix_t *restrict src, double factor)
+matrix_t *matrix_scale(matrix_t *dst, double factor)
 {
-    assert(matrix_same_dimensions(dst, src));
-    pmt_vec_scale(dst->values, src->values, factor, matrix_size(dst));
+    pmt_vec_scale(dst->values, factor, matrix_size(dst));
     return dst;
 }

--- a/sources/matrix/matrix_scale_to.c
+++ b/sources/matrix/matrix_scale_to.c
@@ -1,7 +1,9 @@
 #include "matrix.h"
 
-matrix_t *matrix_scale_to(matrix_t *dst, double factor)
+matrix_t *matrix_scale_to(
+    matrix_t *restrict dst, const matrix_t *restrict src, double factor)
 {
-    pmt_vec_scale_to(dst->values, factor, matrix_size(dst));
+    assert(matrix_same_dimensions(dst, src));
+    pmt_vec_scale_to(dst->values, src->values, factor, matrix_size(dst));
     return dst;
 }

--- a/sources/matrix/matrix_sub.c
+++ b/sources/matrix/matrix_sub.c
@@ -1,10 +1,8 @@
 #include "matrix.h"
 
-matrix_t *matrix_sub(matrix_t *restrict dst, const matrix_t *restrict lhs,
-    const matrix_t *restrict rhs)
+matrix_t *matrix_sub(matrix_t *restrict dst, const matrix_t *restrict src)
 {
-    assert(matrix_same_dimensions(dst, lhs));
-    assert(matrix_same_dimensions(dst, rhs));
-    pmt_vec_sub(dst->values, lhs->values, rhs->values, matrix_size(dst));
+    assert(matrix_same_dimensions(dst, src));
+    pmt_vec_sub(dst->values, src->values, matrix_size(dst));
     return dst;
 }

--- a/sources/matrix/matrix_sub_to.c
+++ b/sources/matrix/matrix_sub_to.c
@@ -1,8 +1,10 @@
 #include "matrix.h"
 
-matrix_t *matrix_sub_to(matrix_t *restrict dst, const matrix_t *restrict src)
+matrix_t *matrix_sub_to(matrix_t *restrict dst, const matrix_t *restrict lhs,
+    const matrix_t *restrict rhs)
 {
-    assert(matrix_same_dimensions(dst, src));
-    pmt_vec_sub_to(dst->values, src->values, matrix_size(dst));
+    assert(matrix_same_dimensions(dst, lhs));
+    assert(matrix_same_dimensions(dst, rhs));
+    pmt_vec_sub_to(dst->values, lhs->values, rhs->values, matrix_size(dst));
     return dst;
 }

--- a/sources/primitives/pmt_vec_add.c
+++ b/sources/primitives/pmt_vec_add.c
@@ -1,9 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_add(double *restrict dst, const double *restrict lhs,
-    const double *restrict rhs, size_t size)
+double *pmt_vec_add(
+    double *restrict dst, const double *restrict src, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] + rhs[i];
+    for (size_t i = 0; i < size; ++i) dst[i] += src[i];
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_add_to.c
+++ b/sources/primitives/pmt_vec_add_to.c
@@ -1,9 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_add_to(
-    double *restrict dst, const double *restrict src, size_t size)
+double *pmt_vec_add_to(double *restrict dst, const double *restrict lhs,
+    const double *restrict rhs, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] += src[i];
+    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] + rhs[i];
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_fma.c
+++ b/sources/primitives/pmt_vec_fma.c
@@ -1,9 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_fma(double *restrict dst, const double *restrict lhs,
-    double factor, const double *restrict rhs, size_t size)
+double *pmt_vec_fma(double *restrict dst, const double *restrict src,
+    double factor, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] * factor + rhs[i];
+    for (size_t i = 0; i < size; ++i) dst[i] += src[i] * factor;
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_fma_to.c
+++ b/sources/primitives/pmt_vec_fma_to.c
@@ -1,9 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_fma_to(double *restrict dst, const double *restrict src,
-    double factor, size_t size)
+double *pmt_vec_fma_to(double *restrict dst, const double *restrict lhs,
+    double factor, const double *restrict rhs, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] += src[i] * factor;
+    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] * factor + rhs[i];
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_scale.c
+++ b/sources/primitives/pmt_vec_scale.c
@@ -1,9 +1,8 @@
 #include "primitives.h"
 
-double *pmt_vec_scale(double *restrict dst, const double *restrict src,
-    double factor, size_t size)
+double *pmt_vec_scale(double *dst, double factor, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] = src[i] * factor;
+    for (size_t i = 0; i < size; ++i) dst[i] *= factor;
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_scale_to.c
+++ b/sources/primitives/pmt_vec_scale_to.c
@@ -1,8 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_scale_to(double *dst, double factor, size_t size)
+double *pmt_vec_scale_to(double *restrict dst, const double *restrict src,
+    double factor, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] *= factor;
+    for (size_t i = 0; i < size; ++i) dst[i] = src[i] * factor;
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_sub.c
+++ b/sources/primitives/pmt_vec_sub.c
@@ -1,9 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_sub(double *restrict dst, const double *restrict lhs,
-    const double *restrict rhs, size_t size)
+double *pmt_vec_sub(
+    double *restrict dst, const double *restrict src, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] - rhs[i];
+    for (size_t i = 0; i < size; ++i) dst[i] -= src[i];
 
     return dst;
 }

--- a/sources/primitives/pmt_vec_sub_to.c
+++ b/sources/primitives/pmt_vec_sub_to.c
@@ -1,9 +1,9 @@
 #include "primitives.h"
 
-double *pmt_vec_sub_to(
-    double *restrict dst, const double *restrict src, size_t size)
+double *pmt_vec_sub_to(double *restrict dst, const double *restrict lhs,
+    const double *restrict rhs, size_t size)
 {
-    for (size_t i = 0; i < size; ++i) dst[i] -= src[i];
+    for (size_t i = 0; i < size; ++i) dst[i] = lhs[i] - rhs[i];
 
     return dst;
 }

--- a/sources/vector/vector_add.c
+++ b/sources/vector/vector_add.c
@@ -1,10 +1,8 @@
 #include "vector.h"
 
-vector_t *vector_add(vector_t *restrict dst, const vector_t *restrict lhs,
-    const vector_t *restrict rhs)
+vector_t *vector_add(vector_t *restrict dst, const vector_t *restrict src)
 {
-    assert(dst->count == lhs->count);
-    assert(dst->count == rhs->count);
-    pmt_vec_add(dst->values, lhs->values, rhs->values, dst->count);
+    assert(dst->count == src->count);
+    pmt_vec_add(dst->values, src->values, dst->count);
     return dst;
 }

--- a/sources/vector/vector_add_to.c
+++ b/sources/vector/vector_add_to.c
@@ -1,8 +1,10 @@
 #include "vector.h"
 
-vector_t *vector_add_to(vector_t *restrict dst, const vector_t *restrict src)
+vector_t *vector_add_to(vector_t *restrict dst, const vector_t *restrict lhs,
+    const vector_t *restrict rhs)
 {
-    assert(dst->count == src->count);
-    pmt_vec_add_to(dst->values, src->values, dst->count);
+    assert(dst->count == lhs->count);
+    assert(dst->count == rhs->count);
+    pmt_vec_add_to(dst->values, lhs->values, rhs->values, dst->count);
     return dst;
 }

--- a/sources/vector/vector_lerp.c
+++ b/sources/vector/vector_lerp.c
@@ -1,0 +1,10 @@
+#include "vector.h"
+
+vector_t *vector_lerp(vector_t *restrict dst,
+    const vector_t *restrict src, double t)
+{
+    assert(dst->count == src->count);
+    pmt_vec_scale(dst->values, 1.0 - t, dst->count);
+    pmt_vec_fma(dst->values, src->values, t, dst->count);
+    return dst;
+}

--- a/sources/vector/vector_lerp_to.c
+++ b/sources/vector/vector_lerp_to.c
@@ -1,0 +1,9 @@
+#include "vector.h"
+
+vector_t *vector_lerp_to(vector_t *restrict dst,
+    const vector_t *restrict lhs, const vector_t *restrict rhs, double t)
+{
+    assert(dst->count == lhs->count);
+    assert(dst->count == rhs->count);
+    pmt_vec_scale_to(
+}

--- a/sources/vector/vector_linear_combine.c
+++ b/sources/vector/vector_linear_combine.c
@@ -6,12 +6,12 @@ vector_t *vector_linear_combine(vector_t *restrict dst,
     if (coeffs->count == 0) return dst;
 
     assert(dst->count == src->count);
-    pmt_vec_scale(dst->values, src->values, coeffs->values[0], dst->count);
+    pmt_vec_scale_to(dst->values, src->values, coeffs->values[0], dst->count);
 
     for (size_t i = 1; i < coeffs->count; ++i)
     {
         assert(dst->count == (src + i)->count);
-        pmt_vec_fma_to(
+        pmt_vec_fma(
             dst->values, (src + i)->values, coeffs->values[i], dst->count);
     }
 

--- a/sources/vector/vector_scale.c
+++ b/sources/vector/vector_scale.c
@@ -1,9 +1,7 @@
 #include "vector.h"
 
-vector_t *vector_scale(
-    vector_t *restrict dst, const vector_t *restrict src, double factor)
+vector_t *vector_scale(vector_t *dst, double factor)
 {
-    assert(dst->count == src->count);
-    pmt_vec_scale(dst->values, src->values, factor, dst->count);
+    pmt_vec_scale(dst->values, factor, dst->count);
     return dst;
 }

--- a/sources/vector/vector_scale_to.c
+++ b/sources/vector/vector_scale_to.c
@@ -1,7 +1,9 @@
 #include "vector.h"
 
-vector_t *vector_scale_to(vector_t *dst, double factor)
+vector_t *vector_scale_to(
+    vector_t *restrict dst, const vector_t *restrict src, double factor)
 {
-    pmt_vec_scale_to(dst->values, factor, dst->count);
+    assert(dst->count == src->count);
+    pmt_vec_scale_to(dst->values, src->values, factor, dst->count);
     return dst;
 }

--- a/sources/vector/vector_sub.c
+++ b/sources/vector/vector_sub.c
@@ -1,10 +1,8 @@
 #include "vector.h"
 
-vector_t *vector_sub(vector_t *restrict dst, const vector_t *restrict lhs,
-    const vector_t *restrict rhs)
+vector_t *vector_sub(vector_t *restrict dst, const vector_t *restrict src)
 {
-    assert(dst->count == lhs->count);
-    assert(dst->count == rhs->count);
-    pmt_vec_sub(dst->values, lhs->values, rhs->values, dst->count);
+    assert(dst->count == src->count);
+    pmt_vec_sub(dst->values, src->values, dst->count);
     return dst;
 }

--- a/sources/vector/vector_sub_to.c
+++ b/sources/vector/vector_sub_to.c
@@ -1,8 +1,10 @@
 #include "vector.h"
 
-vector_t *vector_sub_to(vector_t *restrict dst, const vector_t *restrict src)
+vector_t *vector_sub_to(vector_t *restrict dst, const vector_t *restrict lhs,
+    const vector_t *restrict rhs)
 {
-    assert(dst->count == src->count);
-    pmt_vec_sub_to(dst->values, src->values, dst->count);
+    assert(dst->count == lhs->count);
+    assert(dst->count == rhs->count);
+    pmt_vec_sub_to(dst->values, lhs->values, rhs->values, dst->count);
     return dst;
 }


### PR DESCRIPTION
Also change the API by making the _to suffix only appear for functions that add an indirection to the computations' destination buffer.